### PR TITLE
Optimize production builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ RUN npm run pre:${APP_MODE}
 
 CMD [\
 	"sh", "-c",\
-	"npm run ${APP_MODE:prod}"\
+	"npm run ${APP_MODE:-prod}"\
 	]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,9 @@ EXPOSE 3000
 
 RUN echo "Running in $APP_MODE mode"
 
-RUN chmod +x ./entrypoint.sh
-ENTRYPOINT [ "./entrypoint.sh" ]
+RUN npm run pre:${APP_MODE}
+
+CMD [\
+	"sh", "-c",\
+	"npm run ${APP_MODE:prod}"\
+	]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-if [ "$APP_MODE" = "dev" ]; then
-    npm run dev
-else
-    npm run preview
-fi

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
+    "prod": "npm start",
     "preview": "next build && next start",
     "start": "next start",
     "typecheck": "tsc --noEmit"

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "build": "next build",
     "check": "next lint && tsc --noEmit",
+    "pre:dev": "echo \"Running in dev mode\"",
     "dev": "next dev --turbo",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
+    "pre:prod": "npm run build",
     "prod": "npm start",
     "preview": "next build && next start",
     "start": "next start",


### PR DESCRIPTION
When running in `prod` mode, build is done when building the image and not when running it, reducing time to load on run commands.