### PR TITLE
Fix issue with the hostname variable being static

### DIFF
--- a/src/app/(root)/page.tsx
+++ b/src/app/(root)/page.tsx
@@ -2,6 +2,8 @@ import { HydrateClient } from "~/trpc/server";
 import Hero from "../_components/landingPage/Hero";
 import os from "os";
 
+export const dynamic = "force-dynamic"
+
 export default async function Home() {
   const hostname = os.hostname();
 


### PR DESCRIPTION
Next seems to statically generate this page, and given that we are using a single Docker image to create three frontends, the three of them will have the same value as a hostname, which is Buildkitsandbox because the next build script is being executed by the Dockerfile and not by a container with a hostname like mu_fe-1, mu_fe-2, etc.

I propose to solve this problem by disabling the Static Site Generation of this page with the line in this commit, so that every time the user fetches it the hostname is updated at runtime. I already tested it and it solves our problem